### PR TITLE
Fix: compile error on esp32 github actions

### DIFF
--- a/src/EthernetClient.cpp
+++ b/src/EthernetClient.cpp
@@ -534,7 +534,7 @@ UIPClient::_allocateData()
       uip_userdata_t* data = &UIPClient::all_data[sock];
       if (!data->state)
         {
-          memset(data, 0, sizeof(uip_userdata_t));
+          *data = uip_userdata_t();
           data->conn_index = uip_conn - uip_conns; // pointer arithmetics
           data->state = UIP_CLIENT_CONNECTED;
           return data;

--- a/src/EthernetUdp.cpp
+++ b/src/EthernetUdp.cpp
@@ -34,9 +34,9 @@ extern "C" {
 
 // Constructor
 UIPUDP::UIPUDP() :
-    _uip_udp_conn(NULL)
+    _uip_udp_conn(NULL),
+    appdata()
 {
-  memset(&appdata,0,sizeof(appdata));
 }
 
 // initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
@@ -68,7 +68,7 @@ UIPUDP::stop()
       Enc28J60Network::freeBlock(appdata.packet_in);
       _flushBlocks(appdata.packet_next);
       Enc28J60Network::freeBlock(appdata.packet_out);
-      memset(&appdata,0,sizeof(appdata));
+      appdata = uip_udp_userdata_t();
     }
 }
 


### PR DESCRIPTION
I've encountered [a compile error on esp32 series on Github actions](https://github.com/hideakitai/ArtNet/actions/runs/7470035953/job/20328073449?pr=79) with EthernetENC. 

This PR fixes the compile error caused by `memset()` on the esp32 series.